### PR TITLE
added toString function for 1D UGrid

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,7 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <ScalaCodeStyleSettings>
+      <option name="MULTILINE_STRING_CLOSING_QUOTES_ON_NEW_LINE" value="true" />
+    </ScalaCodeStyleSettings>
+  </code_scheme>
+</component>

--- a/src/main/scala/org/carbonateresearch/conus/grids/universal/UGrid1D.scala
+++ b/src/main/scala/org/carbonateresearch/conus/grids/universal/UGrid1D.scala
@@ -26,8 +26,8 @@ case class UGrid1D(gridGeometry:Seq[Int],
   override val vecSize:Int = gridGeometry.head
 
   override def toString:String = {
-
-  "TODO"
+    ("[" + (0 until gridGeometry.head-1).map(i => underlyingGrid(i).toString() + ",").foldLeft("")(_ + _) +
+      underlyingGrid(gridGeometry.head-1).toString() + "]")
   }
 
 


### PR DESCRIPTION
Added a function that prints the grid variables for the 1D UGrid inside square brackets as follows:
[variable_0, variable_1, ... variable_n].